### PR TITLE
source linking NuGet.Core works with SourceLink.Build 0.2.1

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -2,6 +2,8 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\Build\NuGet.Settings.targets" />
   <PropertyGroup>
+    <SourceLinkRepoUrl>https://raw.github.com/ctaggart/nuget/{0}/%var2%</SourceLinkRepoUrl>
+    <SourceLink Condition="'$(Configuration)'=='Release'">true</SourceLink>
     <ProjectGuid>{F879F274-EFA0-4157-8404-33A19B4E6AEC}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -291,6 +293,7 @@
     <EmbeddedResource Include="Authoring\nuspec.xsd">
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <None Include="packages.config" />
     <None Include="Properties\NuGet.Core.nuspec" />
   </ItemGroup>
   <ItemGroup>
@@ -300,6 +303,7 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\SourceLink.Build.0.2.1\build\SourceLink.Build.targets" Condition="Exists('..\..\packages\SourceLink.Build.0.2.1\build\SourceLink.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Core.csproj requires just two settings to work:

``` xml
<SourceLinkRepoUrl>https://raw.github.com/ctaggart/nuget/{0}/%var2%</SourceLinkRepoUrl>
<SourceLink Condition="'$(Configuration)'=='Release'">true</SourceLink>
```

![nuget](https://f.cloud.github.com/assets/80104/809351/492c8f9a-ee83-11e2-9587-1972ffb69904.png)
